### PR TITLE
volume permissions and createrepo_c

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -47,15 +47,13 @@ This document tracks the large-scale objectives for the Boxed Koji integration t
 ### 🚧 **IN PROGRESS** - Koji Client
 - [x] Basic CLI interface implementation
 - [x] Kerberos authentication integration
-- [ ] Reliability improvements and error handling
-- [ ] Enhanced command coverage
 - [ ] Automated testing integration
 
 ### 🚧 **IN PROGRESS** - Koji Workers
 - [x] Basic worker service structure
 - [x] Resource management via Orch service
-- [x] Docker Compose profile support (`--profile workers`)
-- [ ] Build execution engine
+- [x] Scalable from compose
+- [x] kojid runs
 - [ ] Mock/chroot build environments
 - [ ] Resource scaling and load balancing
 - [ ] Build artifact management
@@ -78,18 +76,14 @@ This document tracks the large-scale objectives for the Boxed Koji integration t
 
 ## 🧪 Testing & Quality Assurance
 
-### 📋 **PLANNED** - Automated Testing Framework
-- [x] Basic test infrastructure (`tests/` directory)
-- [ ] Integration test suite implementation
-- [ ] End-to-end workflow testing
-- [ ] Performance benchmarking
-- [ ] Regression testing automation
-- [ ] Test result reporting and analysis
+### 📋 **PLANNED** - Automated Configuration
+- [x] Initial flexible hub setup via init dir
+- [x] Initial flexible client setup via init dir
+- [ ] Ansible playbook baked into hub to create environment
 
 ### 📋 **PLANNED** - Test Runner Service
 - [x] Service structure in Docker Compose
 - [ ] Automated test execution engine
-- [ ] Test scheduling and orchestration
 - [ ] Result collection and reporting
 - [ ] Integration with CI/CD pipelines
 - [ ] Test environment provisioning
@@ -163,14 +157,7 @@ This document tracks the large-scale objectives for the Boxed Koji integration t
 - [ ] LDAP/Active Directory authentication
 - [ ] Notification system integration (Slack/email)
 - [ ] Artifact storage integration (S3/MinIO)
-
-### 📋 **PLANNED** - API Enhancements
-- [ ] GraphQL API implementation
 - [ ] Webhook system for event notifications
-- [ ] Rate limiting and throttling
-- [ ] API versioning strategy
-- [ ] SDK development for common languages
-- [ ] API documentation automation
 
 ## 📚 Documentation & User Experience
 
@@ -178,16 +165,16 @@ This document tracks the large-scale objectives for the Boxed Koji integration t
 - [x] Basic README with setup instructions
 - [x] Service-specific documentation (Orch service)
 - [x] Architecture overview and diagrams
-- [ ] Comprehensive API documentation
+- [ ] Comprehensive usage documentation
 - [ ] Troubleshooting guides
 - [ ] Best practices documentation
-- [ ] Video tutorials and walkthroughs
 
 ## 🎯 Long-term Vision
 
 
 ### 📋 **PLANNED** - Ecosystem Expansion
 - [ ] Integration with content generators (atomic reactor, osbuild, pnc)
+- [ ] Popular plugins (UMB, koji-smoky-dingo)
 - [ ] Multi-architecture builds
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ pull-koji: ## Clone/update Koji repository
 build: pull-koji ## Build all container images
 	@echo -e "$(BLUE)Building all container images...$(NC)"
 	# we have to explicitly build the common image first because podman-compose build doesn't support additional_context
-	podman-compose build common
+	podman-compose --profile build build common
 	podman-compose build
 	@echo -e "$(GREEN)All images built successfully$(NC)"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,8 @@ services:
     container_name: koji-boxed-common
     scales:
       common: 0
+    profiles:
+      - "build"
 
   postgres:
     image: postgres:15-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,9 +96,9 @@ services:
       DB_IDLE_IN_TRANSACTION_SESSION_TIMEOUT: ${DB_IDLE_IN_TRANSACTION_SESSION_TIMEOUT:-10min}
       DB_IDLE_SESSION_TIMEOUT: ${DB_IDLE_SESSION_TIMEOUT:-0}
     volumes:
-      - postgres_data:/var/lib/postgresql/data:Z
-      - ./services/postgres/init.d:/docker-entrypoint-initdb.d:Z
-      - ./koji-src/:/mnt/koji-src:Z
+      - postgres_data:/var/lib/postgresql/data
+      - ./services/postgres/init.d:/docker-entrypoint-initdb.d:ro,Z
+      - ./koji-src/:/mnt/koji-src:ro,Z
     expose:
       - "5432"
     networks:
@@ -127,7 +127,7 @@ services:
            *common-kadmin]
     volumes:
       - kdc_data:/var/lib/krb5kdc:Z
-      - ./services/kdc/init.d:/var/lib/krb5kdc/kdc-init.d:Z
+      - ./services/kdc/init.d:/var/lib/krb5kdc/kdc-init.d:ro,Z
       - ./data/logs/kdc:/var/log/krb5kdc:Z
     expose:
       - "88"
@@ -172,7 +172,7 @@ services:
     volumes:
       # see SOCKET_README.md for details on using PODMAN_SOCKET with rootless podman
       - ${PODMAN_SOCKET:-/var/run/podman.sock}:/var/run/docker.sock
-      - orch_data:/mnt/data:Z
+      - orch_data:/mnt/data
       - ./services/orch/templates/resource_mapping.yaml.template:/app/resource_mapping.yaml.template:ro,Z
     networks:
       koji-network:
@@ -212,7 +212,7 @@ services:
       KOJI_DEBUG: ${KOJI_DEBUG:-off}
       KOJI_LOG_LEVEL: ${KOJI_LOG_LEVEL:-INFO}
     volumes:
-      - koji_storage:/mnt/koji:Z
+      - koji_storage:/mnt/koji
       - ./services/koji-hub/init.d:/var/lib/koji-hub/hub-init.d:Z
       - ./data/logs/hub:/var/log/koji-hub:Z
     expose:
@@ -251,8 +251,8 @@ services:
       BUILDER_MAX_JOBS: ${BUILDER_MAX_JOBS:-10}
       BUILDER_ARGS: ${BUILDER_ARGS:- --force-lock --verbose}
     volumes:
-      - koji_storage:/mnt/koji:Z
-      - ./data/logs/worker:/var/log/koji-worker
+      - koji_storage:/mnt/koji
+      - ./data/logs/worker:/var/log/koji-worker:Z
     healthcheck:
       test: ["CMD-SHELL", "ps aux | grep -v grep | grep kojid || exit 1"]
       interval: 30s

--- a/services/common/Dockerfile
+++ b/services/common/Dockerfile
@@ -1,9 +1,46 @@
-FROM almalinux:9
-
 # Install system dependencies - consolidated from koji-hub and koji-worker
+
+
+# We need to be running on almalinux:10 in order to have a version of
+# createrepo_c that is compatible with modern fedora repositories. But
+# unfortunately, almalinux:10 EPEL doesn't include tini, which we need for hub
+# and worker and web. So we'll fetch the tini srpm from almalinux:9 and rebuild
+# it on almalinux:10 and then install that in our base image.
+
+
+FROM almalinux:9 as tini-srpm
+
 RUN dnf install -qy dnf-plugins-core epel-release && \
-    dnf config-manager --set-enabled crb && \
-    dnf install -qy \
+    dnf config-manager --set-enabled crb
+
+RUN dnf install -qy yum-utils
+RUN yumdownloader --source tini
+
+
+FROM almalinux:10 as build-tini
+
+RUN dnf install -qy dnf-plugins-core epel-release && \
+    dnf config-manager --set-enabled crb
+
+WORKDIR /build-tini
+RUN mkdir -p /build-tini/SRPMS /build-tini/RPMS
+
+COPY --from=tini-srpm /tini-*.src.rpm /build-tini/SRPMS/tini-*.src.rpm
+
+RUN dnf install -qy rpm-build && \
+    dnf builddep -qy /build-tini/SRPMS/tini-*.src.rpm && \
+    rpmbuild -rb /build-tini/SRPMS/tini-*.src.rpm  && \
+    mv /root/rpmbuild/RPMS/*/*.rpm /build-tini/RPMS/
+
+RUN ls /build-tini/RPMS/
+
+
+FROM almalinux:10
+
+RUN dnf install -qy dnf-plugins-core epel-release && \
+    dnf config-manager --set-enabled crb
+
+RUN dnf install -qy \
     bash \
     diffutils \
     gettext \
@@ -12,6 +49,7 @@ RUN dnf install -qy dnf-plugins-core epel-release && \
     krb5-workstation \
     make \
     openssl \
+    procps-ng \
     python3 \
     python3-dateutil \
     python3-defusedxml \
@@ -27,10 +65,13 @@ RUN dnf install -qy dnf-plugins-core epel-release && \
     python3-six \
     python3-wheel \
     shadow-utils \
-    tini \
     util-linux \
     which && \
     dnf clean all
+
+COPY --from=build-tini /build-tini/RPMS/ /tmp/tini/
+RUN dnf install -qy $(ls -d /tmp/tini/*.rpm | grep 'tini-[0-9].*rpm$') && \
+    rm -rf /tmp/tini/
 
 # Create koji user and group with consistent IDs
 RUN groupadd -g 1000 koji && \

--- a/services/koji-hub/entrypoint.sh
+++ b/services/koji-hub/entrypoint.sh
@@ -13,6 +13,12 @@ log() {
 
 log "Starting Koji Hub entrypoint..."
 
+log "Ensuring /mnt/koji consistency..."
+mkdir -p /mnt/koji/repos /mnt/koji/packages /mnt/koji/builds /mnt/koji/tasks /mnt/koji/scratch
+chmod -R a+rX /mnt/koji/
+ls -al
+
+
 log "Running configure.sh"
 /app/configure.sh
 log "✓ configure.sh completed"

--- a/services/koji-hub/entrypoint.sh
+++ b/services/koji-hub/entrypoint.sh
@@ -10,13 +10,13 @@ set -e
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
 }
-
 log "Starting Koji Hub entrypoint..."
+
 
 log "Ensuring /mnt/koji consistency..."
 mkdir -p /mnt/koji/repos /mnt/koji/packages /mnt/koji/builds /mnt/koji/tasks /mnt/koji/scratch
 chmod -R a+rX /mnt/koji/
-ls -al
+ls -al /mnt/koji/
 
 
 log "Running configure.sh"
@@ -40,6 +40,10 @@ if ! envsubst < /app/httpd.conf.template > /etc/koji-hub/httpd.conf; then
     exit 1
 fi
 cp -f /etc/koji-hub/httpd.conf /etc/httpd/conf.d/kojihub.conf
+
+log "Updating Apache to run as koji user"
+sed -r 's,^(User|Group) apache,\1 koji,g' -i /etc/httpd/conf/httpd.conf
+
 log "✓ Apache configured"
 
 

--- a/services/koji-worker/Dockerfile
+++ b/services/koji-worker/Dockerfile
@@ -9,20 +9,27 @@ RUN dnf install -qy \
     python3-librepo \
     python3-multilib \
     python3-pycdio \
-    yum-utils && \
+    yum-utils \
+    zstd && \
     dnf clean all
 
 # Create worker-specific directories
-RUN mkdir -p /var/log/koji-worker \
+RUN mkdir -p \
+    /var/tmp/koji \
+    /var/log/koji-worker \
+    /var/lib/koji-worker \
+    /var/lib/mock \
+    /var/cache/mock
+
+RUN chown -R koji:koji \
+    /var/tmp/koji \
+    /var/log/koji-worker \
     /var/lib/koji-worker \
     /var/lib/mock \
     /var/cache/mock
 
 
-RUN cp /mnt/koji-src/builder/kojid /app/kojid && \
-    sed -i 's,/usr/bin/python2,/usr/bin/python3,g' /app/kojid && \
-    chmod +x /app/kojid
-
+RUN cp /mnt/koji-src/builder/kojid /app/kojid
 
 # Copy kojid.conf template
 COPY services/koji-worker/kojid.conf.template /app/kojid.conf.template

--- a/services/koji-worker/entrypoint.sh
+++ b/services/koji-worker/entrypoint.sh
@@ -37,6 +37,6 @@ log "✓ kojid.conf generated"
 mkdir -p /etc/mock/koji /var/lib/mock /var/tmp/koji
 
 log "exec'ing kojid"
-exec /app/kojid --fg ${BUILDER_ARGS}
+exec su koji -c "python3 /app/kojid --fg ${BUILDER_ARGS}"
 
 # The end.

--- a/services/orch/entrypoint.sh
+++ b/services/orch/entrypoint.sh
@@ -46,7 +46,7 @@ echo "✓ Directories created"
 
 echo "Orch service initialization complete"
 
-python3 -m gunicorn -w 4 -b 0.0.0.0:5000 app:app &
+python3 -m gunicorn --preload -w 4 -b 0.0.0.0:5000 app:app &
 ORCH_PID=$!
 
 for i in {1..10}; do


### PR DESCRIPTION
Avoid using `:Z` with persistent volumes.

Use `koji:koji` for services that need r/w to /mnt/koji (ie. hub and workers).

update to almalinux 10 to work around issues with createrepo_c not being able to support modern fedora repos, thereby breaking repo regens with external fedora repos.
https://pagure.io/fedora-infrastructure/issue/12282

during the migration to almalinux 10, we lost tini from EPEL. So we also now fetch the tini srpm from almalinux 9 EPEL, then rebuild it under alma 10 so we can install it in the base image.
